### PR TITLE
Add `cte_name` option in the `test` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ from {{ ref('some_model') }}
 ## Available Options
 
 | option                      | description                     | default              | scope*              |
-|-----------------------------|---------------------------------|--------------------|--------------------|
+|-----------------------------|---------------------------------|----------------------|---------------------|
 | **include_missing_columns** | Use the definition of the model to grab the columns not specified in a mock. The columns will be added automatically with *null* values (this option will increase the number of roundtrips to the database when running the test).                          | false | project/test/mock       |
 | **use_database_models**     | Use the models in the database instead of the model SQL. <br> This option is used to simplify the final test query if needed                                      | false | project/test/mock       |
 | **input_format**            | **sql**: use *SELECT* statements to define the mock values. <br> <br> *SELECT 10::int as c1, 20 as c2 <br> UNION ALL <br>  SELECT 30::int as c1, 40 as c2* <br> <br> **csv**: Use tabular form to specify mock values. <br> <br> c1::int \| c2 <br> 10 \| 20 <br> 30 \| 40                            | sql | project/test       |
@@ -379,7 +379,8 @@ from {{ ref('some_model') }}
 | **line_separator**          | Defines the line separator for csv format                       | \\n | project/test       |
 | **type_separator**          | Defines the type separator for csv format                       | :: | project/test       |
 | **use_qualified_sources**   | Use qualified names (source_name + table_name) for sources when building the CTEs for the test query. It allows you to have source models with the same name in different sources/schema.                         | false | project            |
-| **disable_cache**        | Disable cache                             | false| project            |
+| **disable_cache**           | Disable cache                                                   | false| project            |
+
 Notes:
 
 - **scope** is the place where the option can be defined:

--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ from {{ ref('some_model') }}
 | **type_separator**          | Defines the type separator for csv format                       | :: | project/test       |
 | **use_qualified_sources**   | Use qualified names (source_name + table_name) for sources when building the CTEs for the test query. It allows you to have source models with the same name in different sources/schema.                         | false | project            |
 | **disable_cache**           | Disable cache                                                   | false| project            |
+| **cte_name**                | Return the result set of a CTE in the model being tested, rather than the final output. Allows unit tests to be written for given CTEs within a model. If no CTE is provided, the final output will be used (like normal). This assumes that the last line in the model SQL is `select * from final` as per [the dbt-labs style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md#ctes) | none | test |
 
 Notes:
 

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -118,7 +118,7 @@
     compiler error.
   #}
   {%- set re = modules.re -%}
-  {%- set pattern = "(select\s+\*\s+from)\s+final\b" -%}
+  {%- set pattern = "(select\s+\*\s+from)\s+final" -%}
 
   {%- if re.search(pattern, rendered_model_sql, flags=re.IGNORECASE) is none -%}
     {{ exceptions.raise_compiler_error("Unable to find `select * from final` in the model SQL") }}

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -118,10 +118,10 @@
     compiler error.
   #}
   {%- set re = modules.re -%}
-  {%- set pattern = "(from) final" -%}
+  {%- set pattern = "(select\s+\*\s+from)\s+final\b" -%}
 
   {%- if re.search(pattern, rendered_model_sql, flags=re.IGNORECASE) is none -%}
-    {{ exceptions.raise_compiler_error("Unable to find the `select * from final` block in the model SQL") }}
+    {{ exceptions.raise_compiler_error("Unable to find `select * from final` in the model SQL") }}
   {%- else -%}
     {{ return( re.sub(pattern, "\\1 " ~ cte_name, rendered_model_sql, flags=re.IGNORECASE) ) }}
   {%- endif -%}


### PR DESCRIPTION
A copy of the following PR:
* https://github.com/EqualExperts/dbt-unit-testing/pull/134

Just merging this into my fork so that I can (temporarily) use this fork in my dbt packages, until the [EqualExperts/dbt-unit-testing](https://github.com/EqualExperts/dbt-unit-testing) repo has this feature