### PR TITLE
Extend `sql_builders.sql` for SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ from {{ ref('some_model') }}
 ## Available Options
 
 | option                      | description                     | default              | scope*              |
-|-----------------------------|---------------------------------|----------------------|---------------------|
+|-----------------------------|---------------------------------|--------------------|--------------------|
 | **include_missing_columns** | Use the definition of the model to grab the columns not specified in a mock. The columns will be added automatically with *null* values (this option will increase the number of roundtrips to the database when running the test).                          | false | project/test/mock       |
 | **use_database_models**     | Use the models in the database instead of the model SQL. <br> This option is used to simplify the final test query if needed                                      | false | project/test/mock       |
 | **input_format**            | **sql**: use *SELECT* statements to define the mock values. <br> <br> *SELECT 10::int as c1, 20 as c2 <br> UNION ALL <br>  SELECT 30::int as c1, 40 as c2* <br> <br> **csv**: Use tabular form to specify mock values. <br> <br> c1::int \| c2 <br> 10 \| 20 <br> 30 \| 40                            | sql | project/test       |
@@ -379,8 +379,8 @@ from {{ ref('some_model') }}
 | **line_separator**          | Defines the line separator for csv format                       | \\n | project/test       |
 | **type_separator**          | Defines the type separator for csv format                       | :: | project/test       |
 | **use_qualified_sources**   | Use qualified names (source_name + table_name) for sources when building the CTEs for the test query. It allows you to have source models with the same name in different sources/schema.                         | false | project            |
-| **disable_cache**           | Disable cache                                                   | false| project            |
-| **cte_name**                | Return the result set of a CTE in the model being tested, rather than the final output. Allows unit tests to be written for given CTEs within a model. If no CTE is provided, the final output will be used (like normal). This assumes that the last line in the model SQL is `select * from final` as per [the dbt-labs style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md#ctes) | none | test |
+| **disable_cache**        | Disable cache                             | false| project            |
+| **cte_name**                | Return the result set of a CTE in the model being tested, rather than the final output. Allows unit tests to be written for given CTEs within a model. If no CTE is provided, the final output will be used (like normal). This assumes that the last line in the model SQL is `select * from final` as per [the dbt-labs style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md#ctes). | none | test |
 
 Notes:
 

--- a/macros/sql_builders.sql
+++ b/macros/sql_builders.sql
@@ -81,19 +81,7 @@
 
 {% macro build_node_sql(node, complete=false, use_database_models=false) %}
   {%- if use_database_models or node.resource_type in ('source', 'seed') -%}
-    {%- if node.resource_type == "source" %}
-      {% set name = node.identifier %}
-    {%- elif node.resource_type == "snapshot" %}
-      {%- if node.config.alias is not none %}
-        {% set name = node.config.alias %}
-      {%- else %}
-        {% set name = node.name %}
-      {%- endif %}
-    {%- else %}
-      {% set name = node.name %}
-    {%- endif %}
-
-    select * from {{ dbt_unit_testing.quote_identifier(node.database) ~ '.' ~ dbt_unit_testing.quote_identifier(node.schema) ~ '.' ~ dbt_unit_testing.quote_identifier(name) }} where false
+    select * from {{ dbt_unit_testing.model_reference(node) }} where false
   {%- else -%}
     {% if complete %}
       {{ dbt_unit_testing.build_model_complete_sql(node) }}


### PR DESCRIPTION
SQLite doesn't allow a database prefix, so this PR refactors the `build_node_sql` to only use the schema and table names in the object reference (with the database name used in other databases)